### PR TITLE
Fix bare declares

### DIFF
--- a/R/declare_estimator.R
+++ b/R/declare_estimator.R
@@ -112,7 +112,7 @@ declare_estimator <- function(...,
     stop("Please provide ", lbl, " function with a data argument.")
   }
 
-  estimand_label <- if(is.null(estimand)) NULL else attributes(estimand)$label
+  estimand_label <- switch(class(estimand), "character"=estimand, "function"=attributes(estimand)$label)
 
   estimator_function_internal <- function(data) {
     args$data <- data


### PR DESCRIPTION
This fixes bare declare_designs (not in variables), such as:

```
declare_design(
	declare_population(N=100,noise=rnorm(N)),
	declare_potential_outcomes(Y_Z_0=noise, Y_Z_1=noise+1),
	declare_estimand(ATE=mean(Y_Z_1 - Y_Z_0), label="ATE"),
	declare_sampling(n=20),
	declare_assignment(m=10),
	reveal_outcomes(),
	declare_estimator(Y~Z, estimand="ATE")
)
```

It also handles character estimand labels to make the above example join estimators to estimands correctly.