### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,9 +22,7 @@ Imports:
     foreach,
     doRNG,
     parallel
-Remotes: DeclareDesign/estimatr,
-    DeclareDesign/fabricatr
-Additional_repositories: http://install.declaredesign.org
+Additional_repositories: http://r.declaredesign.org
 License: MIT + file LICENSE
 URL: http://declaredesign.org, https://github.com/DeclareDesign/DeclareDesign
 BugReports: https://github.com/DeclareDesign/DeclareDesign/issues


### PR DESCRIPTION
Trying to force appveyor to use drat - when it chooses to install from github, estimatr fails bc rtools is not installed.