### PR TITLE
Fix error dropping dim when there is only one diagnosand

### DIFF
--- a/R/diagnose_design.R
+++ b/R/diagnose_design.R
@@ -257,7 +257,7 @@ diagnose_design_single_design <-
         lapply(
           diagnosands_se_df,
           FUN = function(df) {
-            apply(df[, !colnames(df) %in% group_by_set], 2, sd)
+            apply(df[, !colnames(df) %in% group_by_set, drop = FALSE], 2, sd)
           }
         )
       diagnosands_se_df <- do.call(rbind, diagnosands_se_df)

--- a/tests/testthat/test-diagnosands.R
+++ b/tests/testthat/test-diagnosands.R
@@ -88,6 +88,13 @@ test_that("custom diagnosand function", {
 
   diagnosis$diagnosands
 
+  # works with two with bootstrapping
+  diagnosis <- diagnose_design(my_design, sims = 2, diagnosands = my_dig, bootstrap = TRUE, bootstrap_sims = 2, parallel = FALSE)
+
+  # works with only one diagnosand with bootstrapping (!)
+  my_one_dig <-  declare_diagnosands(se_bias = mean(se - sd(estimand)))
+  diagnosis <- diagnose_design(my_design, sims = 2, diagnosands = my_one_dig, bootstrap = TRUE, parallel = FALSE)
+
 })
 
 


### PR DESCRIPTION
There used to be an error that when bootstrapping with only 1 diagnosand would throw an error. 

The line I change in R/diagnose_design.R keeps `diagnosands_se_df` as a `data.frame` even if the number of columns not in `group_by_set` is only 1. Otherwise, the `apply` command would fail as df would now be of only one dimension.

I add a test that passes as master currently looks with one diagnosand if you don't bootstrap.

However, the second diagnosis, one diagnosand with bootstrapping, only passes with this branch.

The test also serves as an MWE of the error if you have master currently installed.