### PR TITLE
Nfultz/simulation cleanup

### DIFF
--- a/R/declare_potential_outcomes.R
+++ b/R/declare_potential_outcomes.R
@@ -122,7 +122,7 @@ potential_outcomes.formula <- function(formula,
   
   outcome_variable <- as.character(formula[[2]])
   
-  to_restore <- assignment_variables %i% colnames(data)
+  to_restore <- assignment_variables %icn% data
   to_null <- setdiff(assignment_variables, to_restore)
   
   # Build a single large fabricate call -

--- a/R/design_helper_functions.R
+++ b/R/design_helper_functions.R
@@ -175,78 +175,52 @@ draw_data <- function(design) {
 #' @rdname post_design
 #'
 #' @export
-get_estimands <- function(...) {
+get_estimands <- function(...) apply_on_design_dots(get_estimands_single_design, ...)
   
-  designs_quos <- quos(...)
-  designs <- lapply(designs_quos, eval_tidy)
-  
-  ## Two cases:
-  ## 1. send one or more design objects created using the + operator
-  ## 2. send a single list of design objects e.g. created by expand_design
-  ## Approach: unpack designs if a list of designs was sent as a single list object
-  if (length(designs) == 1 &&
-      is.list(designs[[1]]) &&
-      !"design" %in% class(designs[[1]])) {
-    designs <- designs[[1]]
-    names(designs) <- infer_names_list(designs)
-  } else {
-    names(designs) <- infer_names_quos(designs_quos)
-  }
-  
-  ## Do not allow users to send more than one object if any is not a design object
-  if (!all(vapply(designs, inherits, FALSE, "design"))) {
-    stop("Please only send design objects to simulate_design.")
-  }
-  
-  estimands_list <- lapply(designs, get_estimands_single_design)
-  
-  if (length(designs) > 1) {
-    estimands_list <- Map(cbind, design_label = names(estimands_list), estimands_list, stringsAsFactors = FALSE)
-  }
-  
-  estimands_df <- rbind_disjoint(estimands_list)
-  
-  estimands_df
-  
-}
-
 #' @rdname post_design
 #'
 #' @export
-get_estimates <- function(...) {
+get_estimates <- function(...) apply_on_design_dots(get_estimates_single_design, ...)
+
+apply_on_design_dots <- function(FUN, ...) {  
   
-  designs_quos <- quos(...)
-  designs <- lapply(designs_quos, eval_tidy)
+  designs <- dots_to_list_of_designs(...)
   
-  ## Two cases:
-  ## 1. send one or more design objects created using the + operator
-  ## 2. send a single list of design objects e.g. created by expand_design
-  ## Approach: unpack designs if a list of designs was sent as a single list object
-  if (length(designs) == 1 &&
-      is.list(designs[[1]]) &&
-      !"design" %in% class(designs[[1]])) {
-    designs <- designs[[1]]
-    names(designs) <- infer_names_list(designs)
-  } else {
-    names(designs) <- infer_names_quos(designs_quos)
-  }
-  
-  ## Do not allow users to send more than one object if any is not a design object
-  if (!all(vapply(designs, inherits, FALSE, "design"))) {
-    stop("Please only send design objects to simulate_design.")
-  }
-  
-  estimates_list <- lapply(designs, get_estimates_single_design)
+  elist <- lapply(designs, get_estimands_single_design)
   
   if (length(designs) > 1) {
-    estimates_list <- Map(cbind, design_label = names(estimates_list), estimates_list, stringsAsFactors = FALSE)
+    elist <- Map(cbind, design_label = names(elist), elist, stringsAsFactors = FALSE)
   }
   
-  estimates_df <- rbind_disjoint(estimates_list)
-  
-  estimates_df
-  
+  rbind_disjoint(elist)
 }
+
+dots_to_list_of_designs <- function(...) {
+  
+  designs_quos <- enquos(...)
+  
+  d1 <- eval_tidy(designs_quos[[1]])
+
+  ## Two cases:
+  ## 1. send one or more design objects created by the + operator
+  ## 2. send a single list of design objects e.g. created by expand_design
+  ## Approach: unpack designs if a list of designs was sent as a single list object
+  if (length(designs_quos) == 1 &&
+      is.list(d1) &&
+      !inherits(d1, "design")) {
+    designs <- d1
+    names(designs) <- infer_names(designs)
+  } else {
+    names(designs_quos) <- infer_names(designs_quos)
+    designs <- eval_tidy(quo(list(!!!designs_quos)))
+  }
+  
+  # do not allow users to send more than one object if any is not a design object
+  check_design_class(designs)
+  
+  designs
+}
+
 
 get_estimates_single_design <- function(design) {
   results <- list("estimator" = vector("list", length(design)))

--- a/R/design_helper_functions.R
+++ b/R/design_helper_functions.R
@@ -186,7 +186,7 @@ apply_on_design_dots <- function(FUN, ...) {
   
   designs <- dots_to_list_of_designs(...)
   
-  elist <- lapply(designs, get_estimands_single_design)
+  elist <- lapply(designs, FUN)
   
   if (length(designs) > 1) {
     elist <- Map(cbind, design_label = names(elist), elist, stringsAsFactors = FALSE)
@@ -196,23 +196,21 @@ apply_on_design_dots <- function(FUN, ...) {
 }
 
 dots_to_list_of_designs <- function(...) {
-  
-  designs_quos <- enquos(...)
-  
-  d1 <- eval_tidy(designs_quos[[1]])
+  dotqs <- enquos(...)
+  d1 <- eval_tidy(dotqs[[1]])
 
   ## Two cases:
   ## 1. send one or more design objects created by the + operator
   ## 2. send a single list of design objects e.g. created by expand_design
   ## Approach: unpack designs if a list of designs was sent as a single list object
-  if (length(designs_quos) == 1 &&
+  if (length(dotqs) == 1 &&
       is.list(d1) &&
       !inherits(d1, "design")) {
     designs <- d1
     names(designs) <- infer_names(designs)
   } else {
-    names(designs_quos) <- infer_names(designs_quos)
-    designs <- eval_tidy(quo(list(!!!designs_quos)))
+    names(dotqs) <- infer_names(dotqs)
+    designs <- eval_tidy(quo(list(!!!dotqs)))
   }
   
   # do not allow users to send more than one object if any is not a design object
@@ -224,12 +222,12 @@ dots_to_list_of_designs <- function(...) {
 
 get_estimates_single_design <- function(design) {
   results <- list("estimator" = vector("list", length(design)))
-  run_design_internal.design(design, results = results)$estimates_df
+  run_design_internal(design, results = results)$estimates_df
 }
 
 get_estimands_single_design <- function(design) {
   results <- list("estimand" = vector("list", length(design)))
-  run_design_internal.design(design, results = results)$estimands_df
+  run_design_internal(design, results = results)$estimands_df
 }
 
 #' Obtain the preferred citation for a design

--- a/R/diagnose_design.R
+++ b/R/diagnose_design.R
@@ -150,7 +150,7 @@ diagnose_design <- function(...,
 
 }
 
-check_design_class <- function(designs, lbl){
+check_design_class <- function(designs){
   if (!all(sapply(designs, function(x) {
     inherits(x, "design") || ( inherits(x, "function") && is.null(formals(x)))
   }))) {

--- a/R/diagnose_design.R
+++ b/R/diagnose_design.R
@@ -83,7 +83,7 @@ diagnose_design <- function(...,
   # 2. it's something else, and needs to be simulated
   if (is.data.frame(..1)) {
     simulations_df <- ..1
-    if (is_empty(names(simulations_df) %i% c("estimator_label", "estimand_label"))) {
+    if (is_empty(c("estimator_label", "estimand_label") %icn% simulations_df)) {
       stop("Can't calculate diagnosands on this data.frame, which does not include either an estimator_label or an estimand_label. Did you send a simulations data frame?")
     }
   } else {
@@ -98,7 +98,7 @@ diagnose_design <- function(...,
     group_by_set <- c(group_by_set, add_grouping_variables)
   }
 
-  group_by_set <- group_by_set %i% colnames(simulations_df)
+  group_by_set <- group_by_set %icn% simulations_df
 
   # Actually calculate diagnosands ------------------------------------------
 
@@ -134,7 +134,7 @@ diagnose_design <- function(...,
   diagnosands_df$design_label <- factor(diagnosands_df$design_label, levels = parameters_df$design_label)
   
   # Reorder rows
-  sort_by_list <- c(group_by_set, "statistic") %i% colnames(diagnosands_df) 
+  sort_by_list <- c(group_by_set, "statistic") %icn% diagnosands_df
   diagnosands_df <- diagnosands_df[do.call(order, as.list(diagnosands_df[sort_by_list])), , drop = FALSE]
 
   rownames(diagnosands_df) <- NULL
@@ -200,7 +200,7 @@ calculate_sims <- function(simulations_df, group_by_set) {
 
 bootstrap_diagnosands <- function(bootstrap_sims, simulations_df, diagnosands, diagnosands_df, group_by_set) {
   
-  bootstrap_level <- ifelse("fan_1" %in% names(simulations_df), "fan_1", "sim_ID")
+  bootstrap_level <- if("fan_1" %in% names(simulations_df)) "fan_1" else "sim_ID"
   
   boot_indicies_by_id <- split(seq_len(nrow(simulations_df)), simulations_df[, bootstrap_level])
   nsims <- max(simulations_df[, bootstrap_level])
@@ -236,7 +236,7 @@ bootstrap_diagnosands <- function(bootstrap_sims, simulations_df, diagnosands, d
   diagnosands_df <- diagnosands_df[names(labels_df)]
   
   # Calculate standard errors
-  use_vars <- names(diagnosand_replicates)[!(names(diagnosand_replicates) %in% c(group_by_set, "bootstrap_id"))]
+  use_vars <- setdiff(names(diagnosand_replicates), c(group_by_set, "bootstrap_id"))
   diagnosands_se_df <- split(diagnosand_replicates[use_vars], group_by_list, drop = TRUE)
   diagnosands_se_df <- lapply(diagnosands_se_df, lapply, sd)
   

--- a/R/diagnosis_helper_functions.R
+++ b/R/diagnosis_helper_functions.R
@@ -151,7 +151,7 @@ reshape_diagnosis <- function(diagnosis, digits = 2, select = NULL) {
   return_df <- rbind_disjoint(list(diagnosands_only_df, se_only_df), infill = "")
   
   # Reorder rows
-  sort_by_list <- diagnosis$group_by_set %i% colnames(return_df)
+  sort_by_list <- diagnosis$group_by_set %icn% return_df
   return_df <- return_df[do.call(order, as.list(return_df[,sort_by_list])), , drop = FALSE]
   
   # NA bootstrap rows

--- a/R/ops.R
+++ b/R/ops.R
@@ -1,4 +1,7 @@
 
 `%i%` <- intersect
 
+`%icn%` <- function(e1, e2) e1 %i% colnames(e2)
+
+
 `%||%` <- function(e1, e2) if(is.null(e1)) e2 else e1

--- a/R/simulate_design.R
+++ b/R/simulate_design.R
@@ -182,7 +182,7 @@ infer_names <- function(x, type = "design") {
     function(i, xi=x[[i]], nm=inferred_names[i]) {
       if (nm != "") 
         nm
-      else if (!is_quosure(x) || is_call(quo_squash(xi))) 
+      else if (!is_quosure(xi) || is_call(quo_squash(xi))) 
         paste0(type, "_", i)
       else 
         quo_text(xi)

--- a/R/simulate_design.R
+++ b/R/simulate_design.R
@@ -146,7 +146,7 @@ simulate_single_design <- function(design, sims) {
     simulations_df <- merge(
       estimands_df,
       estimates_df,
-      by = colnames(estimands_df) %i% colnames(estimates_df),
+      by = colnames(estimands_df) %icn% estimates_df,
       all = TRUE,
       sort = FALSE
     )

--- a/R/simulate_design.R
+++ b/R/simulate_design.R
@@ -118,9 +118,11 @@ simulate_single_design <- function(design, sims) {
   } else {
     sims <- check_sims(design, sims)
     results_list <- fan_out(design, sims)
-    fan_id <- setNames(rev(do.call(expand.grid, lapply(
-      rev(sims$n), seq
-    ))), paste0("fan_", seq_len(nrow(sims))))
+    fan_id <- setNames(
+      lapply(rev(sims$n), seq),
+      paste0("fan_", seq_len(nrow(sims)))
+    )
+    fan_id <- expand.grid(fan_id)
     fan_id$sim_ID <- seq_len(nrow(fan_id))
   }
   
@@ -136,11 +138,11 @@ simulate_single_design <- function(design, sims) {
   estimates_df <- results2x(results_list, "estimates_df")
   estimands_df <- results2x(results_list, "estimands_df")
   
-  if (nrow(estimates_df) == 0 & nrow(estimands_df) == 0) {
+  if (is_empty(estimates_df) && is_empty(estimands_df)) {
     stop("No estimates or estimands were declared, so design cannot be simulated.", call. = FALSE)
-  } else if (nrow(estimands_df) == 0 && nrow(estimates_df) > 0) {
+  } else if (is_empty(estimands_df)) {
     simulations_df <- estimates_df
-  } else if (nrow(estimands_df) > 0 && nrow(estimates_df) == 0) {
+  } else if (is_empty(estimates_df)) {
     simulations_df <- estimands_df
   } else {
     simulations_df <- merge(
@@ -168,8 +170,8 @@ simulate_single_design <- function(design, sims) {
                  as_list(attr(design, "parameters")),
                  simulations_df[, -1, drop = FALSE])
   }
-  simulations_df
   
+  simulations_df
 }
 
 

--- a/R/simulate_design.R
+++ b/R/simulate_design.R
@@ -47,24 +47,8 @@
 #' Different steps of a design may each be simulated different a number of times, as specified by sims. In this case simulations are grouped into "fans", eg "fan_1" indicates all the simulations that have the same draw from the first level of the design. For efficiency there are generally fewer fans than design steps where all contiguous steps with 1 sim specified are combined into a single fan.
 simulate_design <- function(..., sims = 500) {
     
-    designs_quos <- quos(...)
-    designs <- lapply(designs_quos, eval_tidy)
+    designs <- dots_to_list_of_designs(...)
     
-    ## Two cases:
-    ## 1. send one or more design objects created by the + operator
-    ## 2. send a single list of design objects e.g. created by expand_design
-    ## Approach: unpack designs if a list of designs was sent as a single list object
-     if (length(designs) == 1 &&
-        is.list(designs[[1]]) &&
-        !"design" %in% class(designs[[1]])) {
-      designs <- designs[[1]]
-      names(designs) <- infer_names_list(designs)
-    } else {
-      names(designs) <- infer_names_quos(designs_quos)
-    }
-    
-    # do not allow users to send more than one object if any is not a design object
-    check_design_class(designs)
     
     # if you provide a list of sims for each design, i.e.
     #   sims = list(my_design_1 = c(100, 1, 1), my_design_2 = 200)
@@ -120,132 +104,101 @@ simulate_design <- function(..., sims = 500) {
 
 
 #' @importFrom rlang as_list
-simulate_single_design <-
-  function(design, sims) {
-    if (min(sims) < 1)
-      stop("Sims should be >= 1")
-    
-    # If sims is set correctly, fan out
-    
-    if (length(sims) == 1 && is.null(names(sims))) {
-      results_list <- future_lapply(seq_len(sims),
-                                    function(i)
-                                      run_design(design),
-                                    future.seed = NA, future.globals = "design")
-    } else {
-      sims <- check_sims(design, sims)
-      results_list <- fan_out(design, sims)
-      fan_id <- setNames(rev(do.call(expand.grid, lapply(
-        rev(sims$n), seq
-      ))), paste0("fan_", seq_len(nrow(sims))))
-      fan_id$sim_ID <- seq_len(nrow(fan_id))
-    }
-    
-    results2x <- function(results_list, what) {
-      subresult <- lapply(results_list, `[[`, what)
-      df <- do.call(rbind.data.frame, subresult)
-      if (nrow(df) == 0)
-        return(df)
-      
-      df <- cbind(sim_ID = rep(seq_along(subresult), vapply(subresult, nrow, 0L)), df)
-    }
-    
-    estimates_df <- results2x(results_list, "estimates_df")
-    estimands_df <- results2x(results_list, "estimands_df")
-    
-    if (nrow(estimates_df) == 0 & nrow(estimands_df) == 0) {
-      stop("No estimates or estimands were declared, so design cannot be simulated.", call. = FALSE)
-    } else if (nrow(estimands_df) == 0 && nrow(estimates_df) > 0) {
-      simulations_df <- estimates_df
-    } else if (nrow(estimands_df) > 0 && nrow(estimates_df) == 0) {
-      simulations_df <- estimands_df
-    } else {
-      simulations_df <-
-        merge(
-          estimands_df,
-          estimates_df,
-          by = colnames(estimands_df) %i% colnames(estimates_df),
-          all = TRUE,
-          sort = FALSE
-        )
-      
-      if (nrow(simulations_df) > max(nrow(estimands_df), nrow(estimates_df))) {
-        warning(
-          "Estimators lack estimand/coefficient labels for matching, a many-to-many merge was performed."
-        )
-      }
-    }
-    
-    if (exists("fan_id")) {
-      simulations_df <- merge(simulations_df, fan_id, by = "sim_ID")
-    }
-    
-    if (!is_empty(attr(design, "parameters"))) {
-      simulations_df <-
-        data.frame(simulations_df[, 1, drop = FALSE],
-                   as_list(attr(design, "parameters")),
-                   simulations_df[, -1, drop = FALSE])
-    }
-    simulations_df
-    
+simulate_single_design <- function(design, sims) {
+  if (min(sims) < 1)
+    stop("Sims should be >= 1")
+  
+  # If sims is set correctly, fan out
+  
+  if (length(sims) == 1 && is.null(names(sims))) {
+    results_list <- future_lapply(seq_len(sims),
+                                  function(i)
+                                    run_design(design),
+                                  future.seed = NA, future.globals = "design")
+  } else {
+    sims <- check_sims(design, sims)
+    results_list <- fan_out(design, sims)
+    fan_id <- setNames(rev(do.call(expand.grid, lapply(
+      rev(sims$n), seq
+    ))), paste0("fan_", seq_len(nrow(sims))))
+    fan_id$sim_ID <- seq_len(nrow(fan_id))
   }
-
-
-infer_names_list <-
-  function(x, type = "design") {
+  
+  results2x <- function(results_list, what) {
+    subresult <- lapply(results_list, `[[`, what)
+    df <- do.call(rbind.data.frame, subresult)
+    if (nrow(df) == 0)
+      return(df)
     
-    if (!is.null(names(x))) {
-      inferred_names <- names(x)
-    } else {
-      inferred_names <- rep("", length(x))
-    }
-    missing_names <- inferred_names == ""
-    
-    if (any(missing_names)) {
-      inferred_names[missing_names] <-
-        paste0(type, "_", which(missing_names))
-    }
-    
-    # confirm no dupes
-    if (any(duplicated(inferred_names))) {
-      stop("You have more than one design named ", inferred_names[duplicated(inferred_names)])
-    }
-    
-    inferred_names
+    df <- cbind(sim_ID = rep(seq_along(subresult), vapply(subresult, nrow, 0L)), df)
   }
+  
+  estimates_df <- results2x(results_list, "estimates_df")
+  estimands_df <- results2x(results_list, "estimands_df")
+  
+  if (nrow(estimates_df) == 0 & nrow(estimands_df) == 0) {
+    stop("No estimates or estimands were declared, so design cannot be simulated.", call. = FALSE)
+  } else if (nrow(estimands_df) == 0 && nrow(estimates_df) > 0) {
+    simulations_df <- estimates_df
+  } else if (nrow(estimands_df) > 0 && nrow(estimates_df) == 0) {
+    simulations_df <- estimands_df
+  } else {
+    simulations_df <- merge(
+      estimands_df,
+      estimates_df,
+      by = colnames(estimands_df) %i% colnames(estimates_df),
+      all = TRUE,
+      sort = FALSE
+    )
+    
+    if (nrow(simulations_df) > max(nrow(estimands_df), nrow(estimates_df))) {
+      warning(
+        "Estimators lack estimand/coefficient labels for matching, a many-to-many merge was performed."
+      )
+    }
+  }
+  
+  if (exists("fan_id")) {
+    simulations_df <- merge(simulations_df, fan_id, by = "sim_ID")
+  }
+  
+  if (!is_empty(attr(design, "parameters"))) {
+    simulations_df <-
+      data.frame(simulations_df[, 1, drop = FALSE],
+                 as_list(attr(design, "parameters")),
+                 simulations_df[, -1, drop = FALSE])
+  }
+  simulations_df
+  
+}
+
 
 #' @importFrom rlang quo_squash is_call
-infer_names_quos <-
-  function(x, type = "design") {
-    if (!is.null(names(x))) {
-      inferred_names <- names(x)
-    } else {
-      inferred_names <- rep("", length(x))
-    }
-    missing_names <- inferred_names == ""
-    x_is_call <- sapply(sapply(x, quo_squash, simplify = FALSE), is_call)
-    
-    if (any(missing_names)) {
-      inferred_names[missing_names & x_is_call] <-
-        paste0(type, "_", which(missing_names & x_is_call))
-      inferred_names[missing_names & !x_is_call] <-
-        sapply(x, quo_text)[missing_names & !x_is_call]
-    }
-    
-    # confirm no dupes
-    if (any(duplicated(inferred_names))) {
-      stop("You have more than one design named ", inferred_names[duplicated(inferred_names)])
-    }
-    inferred_names
+infer_names <- function(x, type = "design") {
+  
+  inferred_names <- names(x) %||% rep("", length(x))
+
+  inferred_names <- vapply(seq_along(x), FUN.VALUE = "",
+    function(i, xi=x[[i]], nm=inferred_names[i]) {
+      if (nm != "") 
+        nm
+      else if (!is_quosure(x) || is_call(quo_squash(xi))) 
+        paste0(type, "_", i)
+      else 
+        quo_text(xi)
+  })
+  
+  # confirm no dupes
+  is_dupes <-duplicated(inferred_names)
+  if (any(is_dupes)) {
+    stop("You have more than one ", type, " named ", inferred_names[is_dupes])
   }
+  
+  inferred_names
+}
 
 type_convert <- function(x) {
-  if (inherits(x, "character")) {
-    x <- type.convert(x, as.is = TRUE)
-  } else {
-    x
-  }
-  x
+  if (inherits(x, "character")) type.convert(x, as.is = TRUE) else x
 }
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -207,9 +207,8 @@ step_type.default <- function(x) "unknown"
 
 #' @importFrom rlang is_symbol expr_name
 wrap_step <- function(step, expr) {
-  valid <- is_symbol(expr)
-  lbl <- attr(step, "label")
-  nm <- if(!is_null(lbl)) lbl else if (valid) expr_name(expr) else step_type(step)
+  expr_txt <- if(is_symbol(expr)) expr_name(expr)
+  nm <- attr(step, "label") %||%  expr_txt %||% step_type(step)
   if(is.null(attr(step,"call"))) attr(step, "call") <- expr
-  structure(setNames(list(step), nm), valid=valid)
+  structure(setNames(list(step), nm), valid=!is.null(expr_txt))
 }

--- a/tests/testthat/test-citation.R
+++ b/tests/testthat/test-citation.R
@@ -2,24 +2,26 @@ context("add design citation")
 
 test_that("test with generated citation", {
 
-  design <- 
-    declare_population(data = sleep) + 
-    declare_sampling(n = 10)
+  design <- declare_population(data = sleep) + declare_sampling(n = 10)
   
-  design <- 
-  set_citation(design,
-               author = "Lovelace, Ada",
-               title = "Notes",
-               year = 1953,
-               description = "This is a text description of a design")
+  design <- set_citation(design,
+    author = "Lovelace, Ada",
+    title = "Notes",
+    year = 1953,
+    description = "This is a text description of a design")
   
-  cite <- cite_design(design)
+  expect_output(cite <- cite_design(design), "Ada")
   
   expect_equal(cite, 
-               structure(list(structure(list(title = "Notes", author = structure(list(
-                 list(given = NULL, family = "Lovelace", role = NULL, email = NULL, 
-                      comment = NULL), list(given = NULL, family = "Ada", role = NULL, 
-                                            email = NULL, comment = NULL)), class = "person"), note = "This is a text description of a design", 
+               structure(list(structure(list(
+                 title = "Notes",
+                 author = structure(list(
+                   list(given = NULL, family = "Lovelace",
+                        role = NULL, email = NULL, comment = NULL),
+                   list(given = NULL, family = "Ada",
+                        role = NULL, email = NULL, comment = NULL)),
+                   class = "person"),
+                 note = "This is a text description of a design",
                  year = "1953"), bibtype = "Unpublished")), class = "bibentry"))
   
 })
@@ -28,14 +30,12 @@ test_that("test with user-specified text citation", {
 
   text <- "Set of authors (2017). My custom design."
 
-  design <- 
-    declare_population(data = sleep) + NULL
+  design <- declare_population(data = sleep) + NULL
   
-  design <- 
-    set_citation(design, citation = text)
+  design <- set_citation(design, citation = text)
   
-  expect_equal(cite_design(design), text)
-
+  expect_output(cite <- cite_design(design), paste0('[1] "', text, '"'), fixed=TRUE)
+  expect_equal(cite, text)
 
 })
 

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -57,6 +57,6 @@ test_that("allow design functions to be sent to simulate design and diagnose_des
 test_that("error when you send other objects to diagnose", {
   
   # must send a function or a design object
-  expect_error(diagnose_design(rep(3, 2)), "Please only send design objects or functions with no arguments to simulate_design.")
+  expect_error(diagnose_design(rep(3, 2)), "Please only send design objects or functions with no arguments.")
   
 })

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -45,6 +45,7 @@ test_that("allow design functions to be sent to simulate design and diagnose_des
   
   diag_out <- diagnose_design(my_design_function, sims = 2, bootstrap_sims = FALSE)
   
+  
   expect_equal(diag_out$diagnosands_df[, 1:4], 
                structure(list(design_label = structure(1L, .Label = "my_design_function", class = "factor"), 
                               estimand_label = "ATE", estimator_label = "estimator", 

--- a/tests/testthat/test-fanout.R
+++ b/tests/testthat/test-fanout.R
@@ -54,7 +54,7 @@ test_that("Diagnosing a fanout",{
 
   expect_equivalent(tapply(dx$simulations$est, rep_id[dx$simulations$sim_ID, 3], var), c(0, 0, 0, 0, 0))
   
-  expect_length(paste0("fan_", 1:3) %i% colnames(dx$simulations), 3)
+  expect_length(paste0("fan_", 1:3) %icn% dx$simulations, 3)
 
 })
 
@@ -83,17 +83,3 @@ test_that("sims expansion is correct",{
 })
 
 
-# test_that("fan_out ids are correct",{
-#   sleep_large <- resample_data(sleep, N = 200)
-#   design <- declare_population(sleep_large) +
-#     declare_estimand(2, label = "a") +
-#     declare_estimand(b = rnorm(1))
-#   
-#   fan <- data.frame(end = 1:3, n = c(5, 5, 5))
-# 
-#   fo <- diagnose_design(design, sims = fan)
-# 
-#   fo_id <- fo$simulations[paste0("fan_", 1:3)]
-# 
-#   expect_equal(nrow(unique(fo_id)), prod(fan$n))
-# })


### PR DESCRIPTION
removing copied code from get_estimates/estimands/simulate/diagnose, makes helper function instead.

as a consequence, all of theoe now also work with anything that has a run_design_internal method (eg functions with zero args), all though many combinations are not tested at this point. 