### PR TITLE
WIP revert to fabricate as default for declare_step

### DIFF
--- a/R/declare_step.R
+++ b/R/declare_step.R
@@ -10,8 +10,15 @@
 #' N <- 50
 #' my_population <- declare_population(N = N, noise = rnorm(N))
 #' my_assignment <- declare_assignment(m = 25)
-#' my_step <- declare_step(fabricate, Z2 = Z, q = 5)
+#' 
+#' # use fabricate as the custom step
+#' my_step <- declare_step(handler = fabricate, Z2 = Z, q = 5)
+#'
+#' design <- my_population + my_assignment + my_step
+#' 
+#' # use dplyr's mutate
+#' my_step <- declare_step(handler = dplyr::mutate, Z2 = Z, q = 5)
 #'
 #' design <- my_population + my_assignment + my_step
 #'
-declare_step <- make_declarations(function(data, ...f, ...) ...f(data, ...), "custom")
+declare_step <- make_declarations(fabricate, "custom")

--- a/man/declare_step.Rd
+++ b/man/declare_step.Rd
@@ -4,8 +4,7 @@
 \alias{declare_step}
 \title{Declare a custom step}
 \usage{
-declare_step(..., handler = function(data, ...f, ...) ...f(data, ...),
-  label = NULL)
+declare_step(..., handler = fabricate, label = NULL)
 }
 \arguments{
 \item{...}{arguments to be captured, and later passed to the handler}
@@ -25,7 +24,14 @@ With declare_step, you can include any function that takes data as one of its ar
 N <- 50
 my_population <- declare_population(N = N, noise = rnorm(N))
 my_assignment <- declare_assignment(m = 25)
+
+# use fabricate as the custom step
 my_step <- declare_step(fabricate, Z2 = Z, q = 5)
+
+design <- my_population + my_assignment + my_step
+
+# use dplyr's mutate
+my_step <- declare_step(dplyr::mutate, Z2 = Z, q = 5)
 
 design <- my_population + my_assignment + my_step
 


### PR DESCRIPTION
- default use of fabricate works

TODO: dplyr support is broken:

```
N <- 50
my_population <- declare_population(N = N, noise = rnorm(N))
my_assignment <- declare_assignment(m = 25)

# one syntax
my_step <- declare_step(handler = dplyr::mutate, Z2 = Z, q = 5)

design <- my_population + my_assignment + my_step

> draw_data(design)
 Error: Error in step 3 ():
	Error in tbl_df(.data): argument ".data" is missing, with no default 


# another syntax
my_step <- declare_step(dplyr::mutate, Z2 = Z, q = 5)

design <- my_population + my_assignment + my_step
> draw_data(design)
 Error: Error in step 3 ():
	Error in check_variables_named(data_arguments, "modify_level"): All variables inside a level call must be named. This modify_level call contained 3 variables but 2 named variables. In order, the variables supplied were named: <unnamed>, Z2, q. 
```