### PR TITLE
removing na.rm for diagnosands

### DIFF
--- a/R/declare_diagnosands.R
+++ b/R/declare_diagnosands.R
@@ -4,7 +4,6 @@
 #' @param keep_defaults A flag for whether to report the default diagnosands. Defaults to \code{TRUE}.
 #' @param subset A subset of the simulations data frame within which to calculate diagnosands e.g. \code{subset = p.value < .05}.
 #' @param alpha Alpha significance level. Defaults to \code{.05}.
-#' @param na.rm logical. Should simulations with missing estimates be dropped? Defaults to TRUE.
 #' @param label Label for the set of diagnosands.
 #' @param data a data.frame
 #'
@@ -22,22 +21,21 @@ diagnosand_handler <- function(data, ...,
                                keep_defaults = TRUE,
                                subset = NULL,
                                alpha = 0.05,
-                               na.rm = TRUE,
                                label) {
   options <- quos(...)
-
+  
   if (length(options) > 0 && names(options)[1] == "") names(options)[1] <- label
-
+  
   # subsetting the data -----------------------------------------------------
-
+  
   subset <- enquo(subset)
   idx <- eval_tidy(subset, data = data)
   if (!is.null(idx)) {
     data <- data[idx, , drop = FALSE]
   }
-
+  
   # defaults ----------------------------------------------------------------
-
+  
   defaults_quos <-
     quos(
       bias = mean(estimate - estimand),
@@ -50,34 +48,24 @@ diagnosand_handler <- function(data, ...,
       type_s_rate = mean((sign(estimate) != sign(estimand))[ p.value < alpha ]),
       mean_estimand = mean(estimand)
     )
-
+  
   if (!missing(select)) {
     select_quo <- enquo(select)
     select_set <- reveal_nse_helper(select_quo)
     defaults_quos <- defaults_quos[select_set]
   }
-
+  
   if (!missing(subtract)) {
     subtract_quo <- enquo(subtract)
     subtract_set <- reveal_nse_helper(subtract_quo)
     defaults_quos <- defaults_quos[!names(defaults_quos) %in% subtract_set]
   }
-
+  
   if (keep_defaults) {
     options <- c(options, defaults_quos[!names(defaults_quos) %in% names(options)])
   }
-
-  ret <- vector("list", length(options))
   
-  if(na.rm){
-    n_row_original <- nrow(data)
-    data <- na.omit(data)
-    n_deleted <- n_row_original - nrow(data)
-    
-    na_ret <- data.frame(diagnosand_label = "n_deleted",
-                         diagnosand = n_deleted,
-                         stringsAsFactors = FALSE)
-  }
+  ret <- vector("list", length(options))
   
   for (i in seq_along(options)) {
     ret[i] <- eval_tidy(options[[i]], data = data)
@@ -85,17 +73,12 @@ diagnosand_handler <- function(data, ...,
   
   ret <- simplify2array(ret)
   
-  ret <- 
   data.frame(
     diagnosand_label = names(options),
     diagnosand = ret,
     stringsAsFactors = FALSE
   )
   
-  if(na.rm){
-    ret <- rbind_disjoint(list(ret, na_ret))
-  }
-  ret
 }
 
 
@@ -103,56 +86,56 @@ validation_fn(diagnosand_handler) <- function(ret, dots, label) {
   if (sum(c("select", "subtract") %in% names(dots)) > 1) {
     stop("You may not provide arguments to `select` and `subtract` at the same time.", call. = FALSE)
   }
-
+  
   default_diagnosand_names <-
     c(
       "bias", "rmse", "power", "coverage", "mean_estimate", "sd_estimate",
       "mean_se", "type_s_rate", "mean_estimand"
     )
-
+  
   if ("select" %in% names(dots)) {
     select_set <- reveal_nse_helper(dots[["select"]])
-
+    
     if (!all(select_set %in% default_diagnosand_names)) {
       declare_time_error(paste0(
         "Some of your select set are not included in default diagnosands: ",
         paste(select_set[!select_set %in% default_diagnosand_names],
-          collapse = ", "
+              collapse = ", "
         ), "."
       ), ret)
     }
     default_diagnosand_names <- default_diagnosand_names[select_set]
   }
-
+  
   if ("subtract" %in% names(dots)) {
     subtract_set <- reveal_nse_helper(dots[["subtract"]])
-
+    
     if (!all(subtract_set %in% default_diagnosand_names)) {
       declare_time_error(paste0(
         "Some of your subtract set are not included in default diagnosands: ",
         paste(subtract_set[!subtract_set %in% default_diagnosand_names],
-          collapse = ", "
+              collapse = ", "
         ), "."
       ), ret)
     }
     default_diagnosand_names <- default_diagnosand_names[!default_diagnosand_names %in% subtract_set]
   }
-
+  
   options <- names(dots)[!names(dots) %in% c("select", "subtract", "keep_defaults", "subset", "alpha", "label")]
   if (!("keep_defaults" %in% names(dots)) ||
-    ("keep_defaults" %in% names(dots) && eval_tidy(dots[["keep_defaults"]]) == TRUE)) {
+      ("keep_defaults" %in% names(dots) && eval_tidy(dots[["keep_defaults"]]) == TRUE)) {
     options <- c(options, default_diagnosand_names)
   }
-
+  
   if (length(options) == 0) {
     declare_time_error("No diagnosands were declared.", ret)
   }
-
+  
   # check whether all diagnosands are named
   if (is.null(names(dots)) || "" %in% names(dots)) {
     declare_time_error("All diagnosands must be named", ret)
   }
-
+  
   ret
 }
 
@@ -243,17 +226,7 @@ validation_fn(diagnosand_handler) <- function(ret, dots, label) {
 declare_diagnosands <- make_declarations(diagnosand_handler, "diagnosand", "diagnosands")
 
 #' @importFrom stats na.omit
-default_diagnosands <- function(data, alpha = .05, na.rm = TRUE){
-  
-  if(na.rm){
-    n_row_original <- nrow(data)
-    data <- na.omit(data)
-    n_deleted <- n_row_original - nrow(data)
-    
-    na_ret <- data.frame(diagnosand_label = "n_deleted",
-                         diagnosand = n_deleted,
-                         stringsAsFactors = FALSE)
-  }
+default_diagnosands <- function(data, alpha = .05){
   
   estimate <- data$estimate %||% NA
   estimand <- data$estimand %||% NA
@@ -261,7 +234,7 @@ default_diagnosands <- function(data, alpha = .05, na.rm = TRUE){
   std.error <- data$std.error %||% NA
   conf.low <- data$conf.low %||% NA
   conf.high <- data$conf.high %||% NA
-
+  
   bias <- mean(estimate - estimand)
   rmse <- sqrt(mean((estimate - estimand)^2))
   power <- mean(p.value < alpha)
@@ -272,7 +245,6 @@ default_diagnosands <- function(data, alpha = .05, na.rm = TRUE){
   type_s_rate <- mean((sign(estimate) != sign(estimand))[p.value < alpha])
   mean_estimand <- mean(estimand)
   
-  ret <- 
   data.frame(
     diagnosand_label = c(
       "bias",
@@ -299,9 +271,4 @@ default_diagnosands <- function(data, alpha = .05, na.rm = TRUE){
     stringsAsFactors = FALSE
   )
   
-  if(na.rm){
-    ret <- rbind_disjoint(list(ret, na_ret))
-  }
-  
-  ret
 }

--- a/man/declare_diagnosands.Rd
+++ b/man/declare_diagnosands.Rd
@@ -6,7 +6,7 @@
 \title{Declare diagnosands}
 \usage{
 diagnosand_handler(data, ..., select, subtract, keep_defaults = TRUE,
-  subset = NULL, alpha = 0.05, na.rm = TRUE, label)
+  subset = NULL, alpha = 0.05, label)
 
 declare_diagnosands(..., handler = diagnosand_handler, label = NULL)
 }
@@ -24,8 +24,6 @@ declare_diagnosands(..., handler = diagnosand_handler, label = NULL)
 \item{subset}{A subset of the simulations data frame within which to calculate diagnosands e.g. \code{subset = p.value < .05}.}
 
 \item{alpha}{Alpha significance level. Defaults to \code{.05}.}
-
-\item{na.rm}{logical. Should simulations with missing estimates be dropped? Defaults to TRUE.}
 
 \item{label}{Label for the set of diagnosands.}
 

--- a/tests/testthat/test-bootstrap-diagnosands.R
+++ b/tests/testthat/test-bootstrap-diagnosands.R
@@ -30,7 +30,8 @@ test_that("test diagnosands", {
   # default set
 
   diagnosis <- diagnose_design(my_design, sims = 2, bootstrap_sims = 2)
-  expect_equal(dim(diagnosis$diagnosands_df), c(2,25))
+  expect_equal(dim(diagnosis$diagnosands_df), c(2,23))
 
   expect_equal(dim(diagnosis$simulations_df), c(4, 14))
 })
+

--- a/tests/testthat/test-diagnosands.R
+++ b/tests/testthat/test-diagnosands.R
@@ -90,7 +90,7 @@ test_that("test diagnosands without estimands", {
   diagnosis <- diagnose_design(my_design2, sims = 2, diagnosands = my_dig, bootstrap_sims = FALSE)
 
 
-  expect_equal(dim(diagnosis$diagnosands_df), c(1,7))
+  expect_equal(dim(diagnosis$diagnosands_df), c(1,6))
 
 })
 
@@ -160,7 +160,7 @@ test_that("diagnosis, no estimator", {
 
   diagnosand <- declare_diagnosands(z = mean(estimand > 0), keep_defaults = FALSE)
  
-  
+
   expect_equivalent(
     diagnose_design(
       d,
@@ -175,10 +175,7 @@ test_that("diagnosis, no estimator", {
         z = c(1, 1),
         `se(z)` = c(0,
                     0),
-        n_deleted = c(0, 0),
-        `se(n_deleted)` = c(0, 0),
-        n_sims = c(5L,
-                   5L)
+        n_sims = c(5L, 5L)
       ),
       class = "data.frame",
       row.names = c(NA,-2L)
@@ -226,19 +223,36 @@ test_that("diagnosis, NAs if no estimand", {
   d <- declare_population(sleep) + ols
   
   sleep_ols <-
-    structure(list(design_label = structure(1L, .Label = "d", class = "factor"), 
-                   estimator_label = "estimator", term = "group2", bias = NA_real_, 
-                   `se(bias)` = NA_real_, rmse = NA_real_, `se(rmse)` = NA_real_, 
-                   power = 0, `se(power)` = 0, coverage = NA_real_, `se(coverage)` = NA_real_, 
-                   mean_estimate = 1.58, `se(mean_estimate)` = 0, sd_estimate = 0, 
-                   `se(sd_estimate)` = 0, mean_se = 0.849091017238762, `se(mean_se)` = 0, 
-                   type_s_rate = NaN, `se(type_s_rate)` = NA_real_, mean_estimand = NA_real_, 
-                   `se(mean_estimand)` = NA_real_, n_deleted = 0, `se(n_deleted)` = 0, 
-                   n_sims = 4L), class = "data.frame", row.names = c(NA, -1L
-                   ))
+    structure(
+      list(
+        design_label = structure(1L, .Label = "d", class = "factor"),
+        estimator_label = "estimator",
+        term = "group2",
+        bias = NA_real_,
+        `se(bias)` = NA_real_,
+        rmse = NA_real_,
+        `se(rmse)` = NA_real_,
+        power = 0,
+        `se(power)` = 0,
+        coverage = NA_real_,
+        `se(coverage)` = NA_real_,
+        mean_estimate = 1.58,
+        `se(mean_estimate)` = 0,
+        sd_estimate = 0,
+        `se(sd_estimate)` = 0,
+        mean_se = 0.849091017238762,
+        `se(mean_se)` = 0,
+        type_s_rate = NaN,
+        `se(type_s_rate)` = NA_real_,
+        mean_estimand = NA_real_,
+        `se(mean_estimand)` = NA_real_,
+        n_sims = 4L
+      ),
+      class = "data.frame",
+      row.names = c(NA,-1L)
+    )
   
 expect_equivalent(diagnose_design(d, sims = 4, bootstrap_sims = 5)$diagnosands_df, sleep_ols)
-
   
 })
 
@@ -246,16 +260,34 @@ test_that("diagnosis, NAs if no estimand", {
   mu <- declare_estimand(mean(extra))
   d <- declare_population(sleep) + mu
   
-  sleep_ols <- structure(list(design_label = structure(1L, .Label = "d", class = "factor"), 
-                                    estimand_label = "estimand", bias = NA_real_, `se(bias)` = NA_real_, 
-                                    rmse = NA_real_, `se(rmse)` = NA_real_, power = NA_real_, 
-                                    `se(power)` = NA_real_, coverage = NA_real_, `se(coverage)` = NA_real_, 
-                                    mean_estimate = NA_real_, `se(mean_estimate)` = NA_real_, 
-                                    sd_estimate = NA_real_, `se(sd_estimate)` = NA_real_, mean_se = NA_real_, 
-                                    `se(mean_se)` = NA_real_, type_s_rate = NA_real_, `se(type_s_rate)` = NA_real_, 
-                                    mean_estimand = 1.54, `se(mean_estimand)` = 0, n_deleted = 0, 
-                                    `se(n_deleted)` = 0, n_sims = 4L), class = "data.frame", row.names = c(NA, 
-                                                                                                           -1L))
+  sleep_ols <-
+    structure(
+      list(
+        design_label = structure(1L, .Label = "d", class = "factor"),
+        estimand_label = "estimand",
+        bias = NA_real_,
+        `se(bias)` = NA_real_,
+        rmse = NA_real_,
+        `se(rmse)` = NA_real_,
+        power = NA_real_,
+        `se(power)` = NA_real_,
+        coverage = NA_real_,
+        `se(coverage)` = NA_real_,
+        mean_estimate = NA_real_,
+        `se(mean_estimate)` = NA_real_,
+        sd_estimate = NA_real_,
+        `se(sd_estimate)` = NA_real_,
+        mean_se = NA_real_,
+        `se(mean_se)` = NA_real_,
+        type_s_rate = NA_real_,
+        `se(type_s_rate)` = NA_real_,
+        mean_estimand = 1.54,
+        `se(mean_estimand)` = 0,
+        n_sims = 4L
+      ),
+      class = "data.frame",
+      row.names = c(NA,-1L)
+    )
     expect_equivalent(diagnose_design(d, sims = 4)$diagnosands_df, sleep_ols)
 })
 
@@ -329,51 +361,51 @@ test_that("declare time errors", {
 })
 
 
-test_that("missingness",{
-  
-  my_population <- declare_population(N = 50, noise = rnorm(N))
-  fixed_pop <-  my_population()
-  my_pop <- declare_population(fixed_pop)
-
-  my_odd_estimator <- function(data) {
-    estimate = rnorm(1)
-    if(estimate > 0){
-      estimate <- NA
-    }
-    data.frame(estimate = estimate)
-  }
-  # my_odd_estimator(my_pop)
-  estimator <- declare_estimator(handler = my_odd_estimator)
-  des <- my_pop + estimator
-  
-  dx <- diagnose_design(des, sims = 50, bootstrap_sims = FALSE)
-  expect_equal(
-    names(dx$diagnosands_df),
-    c(
-      "design_label",
-      "bias",
-      "rmse",
-      "power",
-      "coverage",
-      "mean_estimate",
-      "sd_estimate",
-      "mean_se",
-      "type_s_rate",
-      "mean_estimand",
-      "n_deleted",
-      "n_sims"
-    )
-  )
-  
-  diags <- declare_diagnosands(select = c(mean_estimate), na.rm = TRUE)
-  dx <- diagnose_design(des, sims = 50, diagnosands = diags, bootstrap_sims = FALSE)
-  expect_equal(names(dx$diagnosands_df), c("design_label", "mean_estimate", "n_deleted", "n_sims"))
-  
-  diags <- declare_diagnosands(select = c(mean_estimate), na.rm = FALSE)
-  dx <- diagnose_design(des, sims = 50, diagnosands = diags, bootstrap_sims = FALSE)
-  expect_equal(names(dx$diagnosands_df), c("design_label", "mean_estimate", "n_sims"))
-  
-  
-})
+# test_that("missingness",{
+#   
+#   my_population <- declare_population(N = 50, noise = rnorm(N))
+#   fixed_pop <-  my_population()
+#   my_pop <- declare_population(fixed_pop)
+# 
+#   my_odd_estimator <- function(data) {
+#     estimate = rnorm(1)
+#     if(estimate > 0){
+#       estimate <- NA
+#     }
+#     data.frame(estimate = estimate)
+#   }
+#   # my_odd_estimator(my_pop)
+#   estimator <- declare_estimator(handler = my_odd_estimator)
+#   des <- my_pop + estimator
+#   
+#   dx <- diagnose_design(des, sims = 50, bootstrap_sims = FALSE)
+#   expect_equal(
+#     names(dx$diagnosands_df),
+#     c(
+#       "design_label",
+#       "bias",
+#       "rmse",
+#       "power",
+#       "coverage",
+#       "mean_estimate",
+#       "sd_estimate",
+#       "mean_se",
+#       "type_s_rate",
+#       "mean_estimand",
+#       "n_deleted",
+#       "n_sims"
+#     )
+#   )
+#   
+#   diags <- declare_diagnosands(select = c(mean_estimate), na.rm = TRUE)
+#   dx <- diagnose_design(des, sims = 50, diagnosands = diags, bootstrap_sims = FALSE)
+#   expect_equal(names(dx$diagnosands_df), c("design_label", "mean_estimate", "n_deleted", "n_sims"))
+#   
+#   diags <- declare_diagnosands(select = c(mean_estimate), na.rm = FALSE)
+#   dx <- diagnose_design(des, sims = 50, diagnosands = diags, bootstrap_sims = FALSE)
+#   expect_equal(names(dx$diagnosands_df), c("design_label", "mean_estimate", "n_sims"))
+#   
+#   
+# })
 
 

--- a/tests/testthat/test-diagnosands.R
+++ b/tests/testthat/test-diagnosands.R
@@ -168,18 +168,10 @@ test_that("diagnosis, no estimator", {
       sims = 5,
       bootstrap_sims = 5
     )$diagnosands_df,
-    structure(
-      list(
-        design_label = structure(c(1L, 1L), .Label = "d", class = "factor"),
-        estimand_label = c("bar", "foo"),
-        z = c(1, 1),
-        `se(z)` = c(0,
-                    0),
-        n_sims = c(5L, 5L)
-      ),
-      class = "data.frame",
-      row.names = c(NA,-2L)
-    ))
+    structure(list(design_label = structure(c(1L, 1L), .Label = "d", class = "factor"), 
+                   estimand_label = c("bar", "foo"), z = c(1, 1), `se(z)` = c(0, 
+                                                                              0), n_sims = c(5L, 5L)), class = "data.frame", row.names = c(NA, 
+                                                                                                                                           -2L)))
 })
 
 test_that("Overriding join conditions", {
@@ -222,35 +214,15 @@ test_that("diagnosis, NAs if no estimand", {
   ols <- declare_estimator(extra ~ group)
   d <- declare_population(sleep) + ols
   
-  sleep_ols <-
-    structure(
-      list(
-        design_label = structure(1L, .Label = "d", class = "factor"),
-        estimator_label = "estimator",
-        term = "group2",
-        bias = NA_real_,
-        `se(bias)` = NA_real_,
-        rmse = NA_real_,
-        `se(rmse)` = NA_real_,
-        power = 0,
-        `se(power)` = 0,
-        coverage = NA_real_,
-        `se(coverage)` = NA_real_,
-        mean_estimate = 1.58,
-        `se(mean_estimate)` = 0,
-        sd_estimate = 0,
-        `se(sd_estimate)` = 0,
-        mean_se = 0.849091017238762,
-        `se(mean_se)` = 0,
-        type_s_rate = NaN,
-        `se(type_s_rate)` = NA_real_,
-        mean_estimand = NA_real_,
-        `se(mean_estimand)` = NA_real_,
-        n_sims = 4L
-      ),
-      class = "data.frame",
-      row.names = c(NA,-1L)
-    )
+  sleep_ols <- structure(list(design_label = structure(1L, .Label = "d", class = "factor"), 
+                             estimator_label = "estimator", term = "group2", bias = NA_real_, 
+                             `se(bias)` = NA_real_, rmse = NA_real_, `se(rmse)` = NA_real_, 
+                             power = 0, `se(power)` = 0, coverage = NA_real_, `se(coverage)` = NA_real_, 
+                             mean_estimate = 1.58, `se(mean_estimate)` = 0, sd_estimate = 0, 
+                             `se(sd_estimate)` = 0, mean_se = 0.849091017238762, `se(mean_se)` = 0, 
+                             type_s_rate = NaN, `se(type_s_rate)` = NA_real_, mean_estimand = NA_real_, 
+                             `se(mean_estimand)` = NA_real_, n_sims = 4L), class = "data.frame", row.names = c(NA, 
+                                                                                                               -1L))
   
 expect_equivalent(diagnose_design(d, sims = 4, bootstrap_sims = 5)$diagnosands_df, sleep_ols)
   
@@ -261,33 +233,16 @@ test_that("diagnosis, NAs if no estimand", {
   d <- declare_population(sleep) + mu
   
   sleep_ols <-
-    structure(
-      list(
-        design_label = structure(1L, .Label = "d", class = "factor"),
-        estimand_label = "estimand",
-        bias = NA_real_,
-        `se(bias)` = NA_real_,
-        rmse = NA_real_,
-        `se(rmse)` = NA_real_,
-        power = NA_real_,
-        `se(power)` = NA_real_,
-        coverage = NA_real_,
-        `se(coverage)` = NA_real_,
-        mean_estimate = NA_real_,
-        `se(mean_estimate)` = NA_real_,
-        sd_estimate = NA_real_,
-        `se(sd_estimate)` = NA_real_,
-        mean_se = NA_real_,
-        `se(mean_se)` = NA_real_,
-        type_s_rate = NA_real_,
-        `se(type_s_rate)` = NA_real_,
-        mean_estimand = 1.54,
-        `se(mean_estimand)` = 0,
-        n_sims = 4L
-      ),
-      class = "data.frame",
-      row.names = c(NA,-1L)
-    )
+    structure(list(design_label = structure(1L, .Label = "d", class = "factor"), 
+                   estimand_label = "estimand", bias = NA_real_, `se(bias)` = NA_real_, 
+                   rmse = NA_real_, `se(rmse)` = NA_real_, power = NA_real_, 
+                   `se(power)` = NA_real_, coverage = NA_real_, `se(coverage)` = NA_real_, 
+                   mean_estimate = NA_real_, `se(mean_estimate)` = NA_real_, 
+                   sd_estimate = NA_real_, `se(sd_estimate)` = NA_real_, mean_se = NA_real_, 
+                   `se(mean_se)` = NA_real_, type_s_rate = NA_real_, `se(type_s_rate)` = NA_real_, 
+                   mean_estimand = 1.54, `se(mean_estimand)` = 0, n_sims = 4L), class = "data.frame", row.names = c(NA, 
+                                                                                                                    -1L))
+  
     expect_equivalent(diagnose_design(d, sims = 4)$diagnosands_df, sleep_ols)
 })
 

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -119,7 +119,7 @@ test_that("default diagnosands work", {
 
   expect_equal(names(diag$diagnosands_df), 
                c("design_label", "estimand_label", "estimator_label", "term", 
-                 "med_bias", "se(med_bias)", "n_deleted", "se(n_deleted)", "n_sims"
+                 "med_bias", "se(med_bias)", "n_sims"
                ))
   
   # w/ set diagnosands each manually
@@ -138,7 +138,7 @@ test_that("default diagnosands work", {
   )
   
   expect_equal(names(diag$diagnosands_df), c("design_label", "estimand_label", "estimator_label", "term", 
-                                             "my_bias", "se(my_bias)", "n_deleted", "se(n_deleted)", "my_power", 
+                                             "my_bias", "se(my_bias)", "my_power", 
                                              "se(my_power)", "n_sims"))
   
   # w/ none set
@@ -154,8 +154,7 @@ test_that("default diagnosands work", {
                  "bias", "se(bias)", "rmse", "se(rmse)", "power", "se(power)", 
                  "coverage", "se(coverage)", "mean_estimate", "se(mean_estimate)", 
                  "sd_estimate", "se(sd_estimate)", "mean_se", "se(mean_se)", "type_s_rate", 
-                 "se(type_s_rate)", "mean_estimand", "se(mean_estimand)", "n_deleted", 
-                 "se(n_deleted)", "n_sims"))
+                 "se(type_s_rate)", "mean_estimand", "se(mean_estimand)", "n_sims"))
   
   # w/ none set and override
 
@@ -168,7 +167,7 @@ test_that("default diagnosands work", {
     
   expect_equal(names(diag$diagnosands_df), 
                c("design_label", "estimand_label", "estimator_label", "term", 
-                 "med_bias", "se(med_bias)", "n_deleted", "se(n_deleted)", "n_sims"
+                 "med_bias", "se(med_bias)", "n_sims"
                ))
   
   
@@ -180,21 +179,21 @@ test_that("default diagnosands work", {
 
   designs <- expand_design(my_designer, N = c(100, 200))
 
-  diag <- diagnose_design(designs, sims = 5, bootstrap_sims = 0)
+  diag <- diagnose_design(designs, sims = 5, bootstrap_sims = FALSE)
  
   expect_equal(names(diag$diagnosands_df), 
                c("design_label", "N", "estimand_label", "estimator_label", "term", 
-                 "med_bias", "n_deleted", "n_sims"))
+                 "med_bias", "n_sims"))
   
   # w mix of diagnosands set
 
   attr(designs[[1]], "diagnosands") <- NULL
 
-  diag <- diagnose_design(designs, sims = 5, bootstrap_sims = 0)
+  diag <- diagnose_design(designs, sims = 5, bootstrap_sims = FALSE)
   
-  expect_equal(ncol(diag$diagnosands_df), 17)
+  expect_equal(ncol(diag$diagnosands_df), 16)
   
   # // simulation df
   sims <- set_diagnosands(simulate_design(designs, sims = 5), declare_diagnosands(med_bias = median(estimate - estimand)))
-  diag <- diagnose_design(sims)
+  diag <- diagnose_design(sims, sims = 5, bootstrap_sims = FALSE)
 })

--- a/tests/testthat/test-factorial.R
+++ b/tests/testthat/test-factorial.R
@@ -40,6 +40,6 @@ test_that("Factorial", {
 
   expect_equal(diagnosis %>% get_simulations %>% dim, c(2, 14))
 
-  expect_equal(diagnosis %>%  get_diagnosands %>% dim, c(1,15))
+  expect_equal(diagnosis %>%  get_diagnosands %>% dim, c(1, 14))
 
 })

--- a/tests/testthat/test-multiple-coefficients.R
+++ b/tests/testthat/test-multiple-coefficients.R
@@ -29,5 +29,5 @@ test_that("Multiple Coefficients", {
 
   expect_equal(diagnosis %>% get_simulations %>% dim, c(4, 12))
 
-  expect_equal(diagnosis %>% get_diagnosands %>% dim, c(2,15))
+  expect_equal(diagnosis %>% get_diagnosands %>% dim, c(2,14))
 })


### PR DESCRIPTION
behavior is pretty annoying for it to list-wise delete. if you have a set of diagnosands that works for one design you send to diagnose_design and not the other, it will return *no* diagnosands for that second design (because it saw NA's for all the irrelevant diagnosands).

undoing this and will come back to it in a more sophisticated way for v2