### PR TITLE
Refactor fanout codepath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache: packages
 warnings_are_errors: false
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
     packages:
       - libudunits2-dev
       - libproj-dev

--- a/R/design_helper_functions.R
+++ b/R/design_helper_functions.R
@@ -57,7 +57,7 @@ check_sims <- function(design, sims) {
         ret[j,] <- c(i,k) 
       } else if(k == 1) {
         ret[j, "end"] <- i
-      } else stop("sims was misspecified")
+      }
     }
     ret <- ret[1:j, , drop=FALSE]
   }

--- a/R/design_helper_functions.R
+++ b/R/design_helper_functions.R
@@ -46,21 +46,26 @@ check_sims <- function(design, sims) {
   }
 
   # Compress sequences of ones into one partial execution
-  include <- rep(TRUE, n)
-  last_1 <- FALSE
-  for (i in n:1) {
-    if (!last_1) {
-      include[i] <- TRUE
-    } else if (ret[i, "n"] == 1 && last_1) include[i] <- FALSE
-
-    last_1 <- ret[i, "n"] == 1
+  
+  ret2 <- ret * 0
+  ret2[1,] <- ret[1,]
+  j <- 1
+  if(n > 1) for(i in 2:n){
+    k <- ret[i, "n"]
+    if(k > 1) {
+      j <- j + 1
+      ret2[j,] <- c(i,k) 
+      
+    } else if(ret[i, "n"] == 1) {
+      ret2[j, "end"] <- i
+      
+    } else stop("")
+    
   }
+  ret2 <- ret2[1:j, , drop=FALSE]
 
-  ret[include, , drop = FALSE]
   
-  # instead of the above, just return rows that vary
-  # ret[ret$n != 1, , drop = FALSE]
-  
+  ret2
 }
 
 #' Execute a design
@@ -122,14 +127,16 @@ run_design_internal.design <- function(design, current_df = NULL, results = NULL
     if ("current_df" %in% names(results)) {
       results[["current_df"]] <- current_df
     }
-    results
+    append(results, list(...))
+    
   } else {
     execution_st(
       design = design,
       current_df = current_df,
       results = results,
       start = i + 1,
-      end = length(design)
+      end = length(design),
+      ...
     )
   }
 }
@@ -163,7 +170,7 @@ run_design_internal.execution_st <- function(design, ...) do.call(run_design_int
 # @param results a list of intermediate results
 # @param start index of starting step
 # @param end  index of ending step
-execution_st <- function(design, current_df = NULL, results = NULL, start = 1, end = length(design)) {
+execution_st <- function(design, current_df = NULL, results = NULL, start = 1, end = length(design), ...) {
   # An execution state are the arguments needed to run run_design
   structure(
     list(
@@ -171,7 +178,8 @@ execution_st <- function(design, current_df = NULL, results = NULL, start = 1, e
       current_df = current_df,
       results = results,
       start = start,
-      end = end
+      end = end,
+      ...
     ),
     class = "execution_st"
   )
@@ -570,9 +578,18 @@ print.summary.design <- function(x, ...) {
 #' @export
 str.design_step <- function(object, ...) cat("design_step:\t", paste0(deparse(attr(object, "call"), width.cutoff = 500L), collapse = ""), "\n")
 
+
+make_fan_counter <- function(fan) {
+  k <- nrow(fan)
+  ret <- matrix(0, 1, k)
+  colnames(ret) <- sprintf("step_%d_draw", c(1, fan$end+1)[1:k])
+  
+  ret
+}
+
 # A wrapper around conduct design for fan-out execution strategies
 fan_out <- function(design, fan) {
-  st <- list(execution_st(design))
+  st <- list(execution_st(design, fan=make_fan_counter(fan)))
 
   for (i in seq_len(nrow(fan))) {
     end <- fan[i, "end"]
@@ -583,8 +600,19 @@ fan_out <- function(design, fan) {
 
     st <- st [ rep(seq_along(st), each = n) ]
 
+    for (j in seq_along(st))
+      st[[j]]$fan[i] <- j
+    
+    
     st <- future_lapply(seq_along(st), function(j) run_design(st[[j]]), future.seed = NA, future.globals = "st")
   }
+  
+  st <- lapply(st, function(x){
+    fan <- x$fan
+    x$fan <- NULL
+    lapply(x, function(x, z=nrow(x)) if(z > 0) cbind(x,fan) else x)
+  })
+  
 
   st
 }

--- a/R/design_helper_functions.R
+++ b/R/design_helper_functions.R
@@ -47,25 +47,22 @@ check_sims <- function(design, sims) {
 
   # Compress sequences of ones into one partial execution
   
-  ret2 <- ret * 0
-  ret2[1,] <- ret[1,]
-  j <- 1
-  if(n > 1) for(i in 2:n){
-    k <- ret[i, "n"]
-    if(k > 1) {
-      j <- j + 1
-      ret2[j,] <- c(i,k) 
-      
-    } else if(ret[i, "n"] == 1) {
-      ret2[j, "end"] <- i
-      
-    } else stop("")
-    
+  if(n > 1) {
+    j <- 1
+    for(i in 2:n){
+      k <- ret[i, "n"]
+      if(k > 1) {
+        #keeper
+        j <- j + 1
+        ret[j,] <- c(i,k) 
+      } else if(k == 1) {
+        ret[j, "end"] <- i
+      } else stop("sims was misspecified")
+    }
+    ret <- ret[1:j, , drop=FALSE]
   }
-  ret2 <- ret2[1:j, , drop=FALSE]
-
   
-  ret2
+  ret
 }
 
 #' Execute a design

--- a/R/simulate_design.R
+++ b/R/simulate_design.R
@@ -131,13 +131,10 @@ simulate_single_design <- function(design, sims) {
   } else {
     sims <- check_sims(design, sims)
     results_list <- fan_out(design, sims)
-    sims2    <- rbind(sims[1,], sims[-1,][sims[-1,]$n!=1,]) # preserve first row; drop all others with n = 1
-    sims2[1,1] <- 1                                         # step_1_draw always ends at 1
-    s        <- setNames(sims2$n, paste0("step_", sims2$end, "_draw"))
-    fan_id   <- do.call(cbind.data.frame, lapply(
-      cumprod(s), function(j)  rep(1:j, each = prod(s)/j)))
-    fan_id$sim_ID <- 1:prod(s)
-    }
+    
+    
+    
+  }
   
   results2x <- function(results_list, what) {
     subresult <- lapply(results_list, `[[`, what)
@@ -204,10 +201,6 @@ simulate_single_design <- function(design, sims) {
         "Estimators lack estimand/term labels for matching, a many-to-many merge was performed."
       )
     }
-  }
-  
-  if (exists("fan_id")) {
-    simulations_df <- merge(simulations_df, fan_id, by = "sim_ID")
   }
   
   if (!is_empty(attr(design, "parameters"))) {

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -201,7 +201,7 @@ test_that("default diagnosands work", {
 
 test_that("with and without term",{
   skip_if_not_installed("DesignLibrary")
-  design_1 <- DesignLibrary::simple_factorial_designer(N = 500, outcome_means = c(0,0,1,2), w_A = 0, w_B = 0)
+  design_1 <- DesignLibrary::simple_factorial_designer(N = 500, outcome_means = c(0,0,1,2), weight_A = 0, weight_B = 0)
   design_2 <- DesignLibrary::multi_arm_designer(N = 500, m_arms = 3, outcome_means = c(0, 0, 1))
   dx <- diagnose_design(design_1, design_2, sims = 3, bootstrap_sims = FALSE)
 

--- a/tests/testthat/test-fanout.R
+++ b/tests/testthat/test-fanout.R
@@ -155,6 +155,7 @@ test_that("correct fan out", {
     simulate_design(declare_population(sleep) + e1 + e2 + e3, sims = c(30, 1, 5, 2))
   
   expect_equivalent(apply(out[,c(5:7)], 2, max), c(30, 150, 300))
+  expect_equivalent(tapply(out$estimand, INDEX = out$estimand_label, max), c(30, 150, 300))
   
 })
 

--- a/tests/testthat/test-fanout.R
+++ b/tests/testthat/test-fanout.R
@@ -12,7 +12,10 @@ test_that("Fanout does something", {
   out <- DeclareDesign:::fan_out(D, fan_strategy)
 
   estimands_out <- do.call(rbind, lapply(out, `[[`, "estimands_df"))
-  expect_equal(nrow(unique(estimands_out)), 1)
+  expect_equal(length(unique(estimands_out$estimand)), 1)
+  expect_equal(estimands_out$step_1_draw, rep(1,100))
+  expect_equal(estimands_out$step_3_draw, 1:100)
+  
 })
 
 test_that("fanout should not be exposed to users", {
@@ -88,13 +91,11 @@ test_that("sims expansion is correct", {
 
   sims <- 2
   expanded <- check_sims(design, sims)
-
-  # compressed final two steps
-  expect_equal(expanded$n, c(2, 1))
+  expect_equal(expanded$n, 2)
 
   sims <- c(a = 2)
   expanded <- check_sims(design, sims)
-  expect_equal(expanded$n, c(1, 2, 1))
+  expect_equal(expanded$n, c(1, 2))
 })
 
 

--- a/tests/testthat/test-simulate-design.R
+++ b/tests/testthat/test-simulate-design.R
@@ -86,5 +86,5 @@ test_that("fan out IDs are correct", {
   
   sx <- simulate_design(design, sims = sims)
   
-  expect_equivalent(apply(sx[,c(15, 16, 17)], 2, max), c(30, 60, 120))
+  expect_equivalent(vapply(sx[c("step_1_draw", "step_3_draw", "step_6_draw")], max, 0), c(30, 60, 120))
 })


### PR DESCRIPTION
The goal of this PR is to make the labeling of IDs for branching sims unambiguous and obvious.

Changes:
  * Can thread through extra bits of data all the way through run_design
  * step compression no longer yields 1:1-steps in middle, so performance win for most common case
  * fan_out book keeping is self-contained 
  * step_x_draw ids will not repeat across cousins - output can be analyzed correctly using tapply
  * step_x_draw column labels now use a helper function, can theoretically be modified without breaking simulate_design

closes #268 
closes #327 