### PR TITLE
add error when a simulations_df is sent with zero rows

### DIFF
--- a/R/diagnose_design.R
+++ b/R/diagnose_design.R
@@ -86,7 +86,7 @@ diagnose_design <- function(...,
       stop("Can't calculate diagnosands on this data.frame, which does not include either an estimator_label or an estimand_label. Did you send a simulations data frame?")
     }
     if (nrow(simulations_df) == 0) {
-      stop("Can't calculate diagnosands on this data.frame, which has no rows.")
+      stop("Can't calculate diagnosands on this data.frame, which has zero rows.")
     }
     diagnosands <- diagnosands %||% attr(simulations_df, "diagnosands") %||% default_diagnosands
   } else {

--- a/R/diagnose_design.R
+++ b/R/diagnose_design.R
@@ -85,6 +85,9 @@ diagnose_design <- function(...,
     if (is_empty(c("estimator_label", "estimand_label") %icn% simulations_df)) {
       stop("Can't calculate diagnosands on this data.frame, which does not include either an estimator_label or an estimand_label. Did you send a simulations data frame?")
     }
+    if (nrow(simulations_df) == 0) {
+      stop("Can't calculate diagnosands on this data.frame, which has no rows.")
+    }
     diagnosands <- diagnosands %||% attr(simulations_df, "diagnosands") %||% default_diagnosands
   } else {
     # simulate if needed ------------------------------------------------------

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -302,5 +302,5 @@ test_that("diagnose_design works when simulations_df lacking parameters attr", {
 
 
 test_that("diagnose_design stops when a zero-row simulations_df is sent", {
-  diagnose_design(data.frame(estimator_label = rep(1, 0)))
+  expect_error(diagnose_design(data.frame(estimator_label = rep(1, 0))), "which has no rows")
 })

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -302,5 +302,5 @@ test_that("diagnose_design works when simulations_df lacking parameters attr", {
 
 
 test_that("diagnose_design stops when a zero-row simulations_df is sent", {
-  expect_error(diagnose_design(data.frame(estimator_label = rep(1, 0))), "which has no rows")
+  expect_error(diagnose_design(data.frame(estimator_label = rep(1, 0))), "which has zero rows")
 })

--- a/tests/testthat/test-diagnose-design.R
+++ b/tests/testthat/test-diagnose-design.R
@@ -299,3 +299,8 @@ test_that("diagnose_design works when simulations_df lacking parameters attr", {
     
   expect_identical(d1,d2)
 })
+
+
+test_that("diagnose_design stops when a zero-row simulations_df is sent", {
+  diagnose_design(data.frame(estimator_label = rep(1, 0)))
+})


### PR DESCRIPTION
This happened when I did simulate_design() then diagnose_design(na.omit(sims)). Edge case, but it was a weird error when it happened.