### PR TITLE
Nfultz/sampling name

### DIFF
--- a/R/declare_sampling.R
+++ b/R/declare_sampling.R
@@ -42,7 +42,7 @@ declare_sampling <- make_declarations(sampling_handler, "sampling")
 #' @importFrom rlang quos !!! call_modify eval_tidy quo
 #' @importFrom randomizr draw_rs obtain_inclusion_probabilities
 #' @rdname declare_sampling
-sampling_handler <- function(data, ..., sampling_variable = "S") {
+sampling_handler <- function(data, ..., sampling_variable = "S", keep = 1) {
   ## draw sample
 
   options <- quos(...)
@@ -63,7 +63,7 @@ sampling_handler <- function(data, ..., sampling_variable = "S") {
   S <- as.character(S)
 
   ## subset to the sampled observations
-  data[ data[[S]] %in% 1, names(data) != S, drop = FALSE]
+  data[ data[[S]] %in% keep,(length(keep) > 1)) | names(data) != S, drop = FALSE]
 }
 
 validation_fn(sampling_handler) <- function(ret, dots, label) {

--- a/R/declare_sampling.R
+++ b/R/declare_sampling.R
@@ -63,7 +63,7 @@ sampling_handler <- function(data, ..., sampling_variable = "S", keep = 1) {
   S <- as.character(S)
 
   ## subset to the sampled observations
-  data[ data[[S]] %in% keep,(length(keep) > 1)) | names(data) != S, drop = FALSE]
+  data[ data[[S]] %in% keep,(length(keep) > 1) | names(data) != S, drop = FALSE]
 }
 
 validation_fn(sampling_handler) <- function(ret, dots, label) {

--- a/R/declare_sampling.R
+++ b/R/declare_sampling.R
@@ -49,15 +49,15 @@ sampling_handler <- function(data, ..., sampling_variable = "S", keep = 1) {
   options <- quos(...)
 
   samp <- reveal_nse_helper(sampling_variable)
-  samp <- as.symbol(paste0(samp, "_inclusion_prob"))
+  samp_inclusion_prob <- as.symbol(paste0(samp, "_inclusion_prob"))
 
-  S <- as.symbol(".__Sample") # Matching old code but also eliminating the R CMD check warning that .__Sample is a undef/global variable
+  S <- as.symbol(samp) # Matching old code but also eliminating the R CMD check warning that .__Sample is a undef/global variable
 
   decl <- eval_tidy(quo(declare_rs(N=!!nrow(data), !!!options)), data)
   
   data <- fabricate(data,
-    !!S := draw_rs(!!decl),
-    !!samp := obtain_inclusion_probabilities(!!decl),
+    !!samp := draw_rs(!!decl),
+    !!samp_inclusion_prob := obtain_inclusion_probabilities(!!decl),
     ID_label = NA
   )
 

--- a/R/declare_sampling.R
+++ b/R/declare_sampling.R
@@ -38,6 +38,7 @@
 declare_sampling <- make_declarations(sampling_handler, "sampling")
 
 #' @param sampling_variable The prefix for the sampling inclusion probability variable.
+#' @param keep The set of sampling outcomes to retain. Use 0:1 to keep the entire population.
 #' @param data A data.frame.
 #' @importFrom rlang quos !!! call_modify eval_tidy quo
 #' @importFrom randomizr draw_rs obtain_inclusion_probabilities

--- a/man/declare_sampling.Rd
+++ b/man/declare_sampling.Rd
@@ -7,7 +7,7 @@
 \usage{
 declare_sampling(..., handler = sampling_handler, label = NULL)
 
-sampling_handler(data, ..., sampling_variable = "S")
+sampling_handler(data, ..., sampling_variable = "S", keep = 1)
 }
 \arguments{
 \item{...}{arguments to be captured, and later passed to the handler}
@@ -19,6 +19,8 @@ sampling_handler(data, ..., sampling_variable = "S")
 \item{data}{A data.frame.}
 
 \item{sampling_variable}{The prefix for the sampling inclusion probability variable.}
+
+\item{keep}{The set of sampling outcomes to retain. Use 0:1 to keep the entire population.}
 }
 \value{
 A function that takes a data.frame as an argument and returns a data.frame subsetted to sampled observations and (optionally) augmented with inclusion probabilities and other quantities.

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -103,3 +103,28 @@ test_that("Factor out declarations", {
   expect_true(inherits(attr(design[[3]], "dots")$declaration, "rs_complete"))
   expect_true(inherits(attr(design[[4]], "dots")$declaration, "ra_complete"))
 })
+
+
+
+
+
+test_that("Keep options on declare_sampling", {
+
+  N <- 500
+  n <- 2
+
+  design1 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n)
+  design2 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n, keep=0)
+  design3 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n, keep=0:1)
+  
+  
+  expect_equal(nrow(draw_data(design1)), n)
+  expect_equal(nrow(draw_data(design2)), N-n)
+
+  expect_equal(
+    table(draw_data(design3)$.__Sample),
+    structure(c(`0` = N-n, `1` = n), .Dim = 2L, .Dimnames = structure(list(
+      c("0", "1")), .Names = ""), class = "table")
+  )
+  
+})

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -115,14 +115,14 @@ test_that("Keep options on declare_sampling", {
 
   design1 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n)
   design2 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n, keep=0)
-  design3 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n, keep=0:1)
+  design3 <- declare_population(N = N, noise = 1:N) + declare_sampling(n = n, keep=0:1, sampling_variable="TestName")
   
   
   expect_equal(nrow(draw_data(design1)), n)
   expect_equal(nrow(draw_data(design2)), N-n)
 
   expect_equal(
-    table(draw_data(design3)$.__Sample),
+    table(draw_data(design3)$TestName),
     structure(c(`0` = N-n, `1` = n), .Dim = 2L, .Dimnames = structure(list(
       c("0", "1")), .Names = ""), class = "table")
   )


### PR DESCRIPTION
Requires #428 

Changes the name of the internal sampling indicator in case it makes it through the DGP..

Closes #427 