### PR TITLE
add drop_nonsampled; add ability to name sampling variable

### DIFF
--- a/man/declare_sampling.Rd
+++ b/man/declare_sampling.Rd
@@ -7,7 +7,7 @@
 \usage{
 declare_sampling(..., handler = sampling_handler, label = NULL)
 
-sampling_handler(data, ..., sampling_variable = "S")
+sampling_handler(data, ..., sampling_variable = "S", drop_nonsampled = TRUE)
 }
 \arguments{
 \item{...}{arguments to be captured, and later passed to the handler}
@@ -19,6 +19,8 @@ sampling_handler(data, ..., sampling_variable = "S")
 \item{data}{A data.frame.}
 
 \item{sampling_variable}{The prefix for the sampling inclusion probability variable.}
+
+\item{drop_nonsampled}{Logical indicating whether to drop units that are not sampled. Default is \code{TRUE}.}
 }
 \value{
 A function that takes a data.frame as an argument and returns a data.frame subsetted to sampled observations and (optionally) augmented with inclusion probabilities and other quantities.

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -103,3 +103,33 @@ test_that("Factor out declarations", {
   expect_true(inherits(attr(design[[3]], "dots")$declaration, "rs_complete"))
   expect_true(inherits(attr(design[[4]], "dots")$declaration, "ra_complete"))
 })
+
+# two by two: keep/drop standard name/non standard name
+
+test_that("keep/drop options work with diff sampling names", {
+  
+  desgn <- declare_population(N = 10) + NULL 
+  
+  dat1 <- draw_data(desgn + declare_sampling(n = 5))
+  dat2 <- draw_data(desgn + declare_sampling(n = 5, drop_nonsampled = TRUE))
+  dat3 <- draw_data(desgn + declare_sampling(n = 5, drop_nonsampled = FALSE))
+  dat4 <- draw_data(desgn + declare_sampling(n = 5, sampling_variable = "smpld"))
+  dat5 <- draw_data(desgn + declare_sampling(n = 5, sampling_variable = "smpld", drop_nonsampled = TRUE))
+  dat6 <- draw_data(desgn + declare_sampling(n = 5, sampling_variable = "smpld", drop_nonsampled = FALSE))
+  
+  # length, which variables
+  expect_equal(nrow(dat1), 5)
+  expect_equal(nrow(dat2), 5)
+  expect_equal(nrow(dat3), 10)
+  expect_false("S" %in% names(dat1))
+  expect_false("S" %in% names(dat2))
+  expect_true("S" %in% names(dat3))
+  
+  expect_equal(nrow(dat4), 5)
+  expect_equal(nrow(dat5), 5)
+  expect_equal(nrow(dat6), 10)
+  expect_false("smpld" %in% names(dat4))
+  expect_false("smpld" %in% names(dat5))
+  expect_true("smpld" %in% names(dat6))
+  
+})


### PR DESCRIPTION
closes https://github.com/DeclareDesign/DeclareDesign/issues/427

built on @nfultz's two PR's #429 #428 but using a logical for dropping