### PR TITLE
cran prep - 0.22.0 patch 

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-03-23.
+Once it is accepted, delete this file and tag the release (commit cafe24a3d7).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2020-03-23.
-Once it is accepted, delete this file and tag the release (commit cafe24a3d7).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DeclareDesign
 Title: Declare and Diagnose Research Designs
-Version: 0.21.0
+Version: 0.22.0
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9164-2102")),
              person("Jasper", "Cooper", email = "jaspercooper@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-8639-3188")),
              person("Alexander", "Coppock", email = "acoppock@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-5733-2386")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DeclareDesign 0.22.0
+
+* Fix ability to set `sampling_variable` in `declare_sampling`. 
+* Add ability to retain nonsampled data after sampling via `drop_nonsampled` flag in `declare_sampling`.
+
 # DeclareDesign 0.20.0
 
 * Add `compare_diagnoses` function to compare two designs on the basis of their design diagnoses. 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Submission
 
-We are resubmitting a small update, `DeclareDesign 0.22.0`, with bug fixes and test changes due to the R 4.0.0 changes to stringsAsFactor.
+We are resubmitting a small update, `DeclareDesign 0.22.0`, with test changes due to the R 4.0.0 changes to stringsAsFactor per email from Kurt as well as a minor feature addition.
 
 Thank you for your time reviewing the submission.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,6 @@
 ## Submission
 
-We are resubmitting a small update, `DeclareDesign 0.20.0`, with bug fixes and the addition of a small new feature. 
-
-We also address an email Kurt raised regarding R's handling of zero-column data frames (which errors in R-devel).
+We are resubmitting a small update, `DeclareDesign 0.22.0`, with bug fixes and test changes due to the R 4.0.0 changes to stringsAsFactor.
 
 Thank you for your time reviewing the submission.
 


### PR DESCRIPTION
* Fix ability to set `sampling_variable` in `declare_sampling`. 
* Add ability to retain nonsampled data after sampling via `drop_nonsampled` flag in `declare_sampling`.
* Test changes to fix errors on CRAN with devel.