### PR TITLE
CRAN prep

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-08-19.
+Once it is accepted, delete this file and tag the release (commit 83947c6).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-02-13.
-Once it is accepted, delete this file and tag the release (commit 1496335).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-08-19.
+Once it is accepted, delete this file and tag the release (commit 07119d4).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-08-19.
-Once it is accepted, delete this file and tag the release (commit 83947c6).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ License: MIT + file LICENSE
 URL: https://declaredesign.org/r/declaredesign, https://github.com/DeclareDesign/DeclareDesign
 BugReports: https://github.com/DeclareDesign/DeclareDesign/issues
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1
 Suggests:
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports:
     rlang, generics, methods
 License: MIT + file LICENSE
-URL: https://declaredesign.org/r/declaredesign, https://github.com/DeclareDesign/DeclareDesign
+URL: https://declaredesign.org/r/declaredesign/, https://github.com/DeclareDesign/DeclareDesign
 BugReports: https://github.com/DeclareDesign/DeclareDesign/issues
 Encoding: UTF-8
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,3 @@ Suggests:
     DesignLibrary,
     coin,
     margins
-Remotes:
-    DeclareDesign/DesignLibrary

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DeclareDesign
 Title: Declare and Diagnose Research Designs
-Version: 0.27.0
+Version: 0.28.0
 Authors@R: c(person("Graeme", "Blair", email = "graeme.blair@ucla.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9164-2102")),
              person("Jasper", "Cooper", email = "jaspercooper@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-8639-3188")),
              person("Alexander", "Coppock", email = "acoppock@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-5733-2386")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# DeclareDesign 0.27.0
+# DeclareDesign 0.28.0
 
 * To simplify output of diagnoses, we changed the names of the variables from design_label to design, inquiry_label to inquiry, and estimator_label to estimator.
 * declare_assignment() and declare_sampling() have the default values for legacy set to FALSE. You can still use the legacy versions of these functions by manually setting legacy = TRUE for some time, but this functionality will later be removed. 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -14,5 +14,7 @@ This update to DeclareDesign completes the transition to non "legacy" syntax for
 
 ## Reverse dependencies
 
+* CausalQueries and DesignLibrary passed
+
 ---
   

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Submission
 
-This is a minor patch switching over from a deprecated syntax to new syntax by default, after waiting nine months for users to transition.
+This is a minor patch switching over from a deprecated syntax to new syntax by default, after waiting nine months for users to transition. Fixed URL redirect in original CRAN submission.
 
 ## Test environments
 * local OS X install (release)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,12 @@
 ## Submission
 
-This update to DeclareDesign completes the transition to non "legacy" syntax for declare_assignment and declare_sampling.
+This is a minor patch switching over from a deprecated syntax to new syntax by default, after waiting nine months for users to transition.
 
 ## Test environments
 * local OS X install (release)
 * ubuntu on github actions (devel, release, oldrel)
-* OS X on Github actions (release, oldrel)
+* windows on github actions (devel, release, oldrel)
+* OS X on Github actions (devel, release, oldrel)
 * win-builder (devel, release, oldrel)
 
 ## R CMD check results

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Submission
 
-Thank you for your time reviewing the submission. We have removed our revdep results, which our submission was kicked back for. Apologies!
+This update to DeclareDesign completes the transition to non "legacy" syntax for declare_assignment and declare_sampling.
 
 ## Test environments
 * local OS X install (release)
@@ -13,8 +13,6 @@ Thank you for your time reviewing the submission. We have removed our revdep res
 0 errors | 0 warnings | 0 notes
 
 ## Reverse dependencies
-
-There is one change to worse in DesignLibrary due to these change. A patch has been prepared and will be submitted to CRAN as soon as this is accepted (the package is maintained by the same team).
 
 ---
   


### PR DESCRIPTION
This PR moves the book syntax to CRAN (main changes are labels and legacy = FALSE by default)