### PR TITLE
add parameter names to sort_by_list

### DIFF
--- a/R/diagnosis_helper_functions.R
+++ b/R/diagnosis_helper_functions.R
@@ -109,6 +109,7 @@ print_summary_diagnosis <- function(x, digits = 2, select = NULL, exclude = NULL
 #' 
 #' reshape_diagnosis(diagnosis, select = c("Bias", "Power"))
 reshape_diagnosis <- function(diagnosis, digits = 2, select = NULL, exclude = NULL) {
+
   diagnosand_columns <- diagnosis$diagnosand_names
 
   diagnosands_df <- diagnosis$diagnosands
@@ -132,7 +133,7 @@ reshape_diagnosis <- function(diagnosis, digits = 2, select = NULL, exclude = NU
   }
 
   # Reorder rows
-  sort_by_list <- diagnosis$group_by_set %icn% return_df
+  sort_by_list <- c(diagnosis$group_by_set %icn% return_df, parameter_names)
 
   return_df <- return_df[do.call(order, as.list(return_df[, sort_by_list])), , drop = FALSE]
 
@@ -142,10 +143,10 @@ reshape_diagnosis <- function(diagnosis, digits = 2, select = NULL, exclude = NU
   }
   return_df$estimator <- as.character(return_df$estimator)
   
-  for(j in c(sort_by_list, parameter_names)) if(is.factor(return_df[[j]]) && !"" %in% levels(return_df[[j]]))
+  for(j in sort_by_list) if(is.factor(return_df[[j]]) && !"" %in% levels(return_df[[j]]))
     return_df[[j]] <- factor(return_df[[j]], levels = c(levels(return_df[[j]]), ""))
   
-  return_df[return_df$statistic == "SE", c(sort_by_list, parameter_names, "n_sims")] <- ""
+  return_df[return_df$statistic == "SE", c(sort_by_list, "n_sims")] <- ""
   return_df$statistic <- NULL
 
   # Make names nicer


### PR DESCRIPTION
parameter names were getting lost with `reshape_diagnosis`  when select invoked see below

note also that the final test in   test-reshape-diagnosis is not reliable as it may produce a vector of length 2 or 3 depending on simulations (`expect_equal(diagnosis$diagnosands_df$significant, structure(c(1L, NA), .Label = "FALSE", class = "factor"))`); this has not be changed here however


e.g.

```
N = 2
design <-  
  declare_model(N = N, Y  = 1:N) +
  declare_estimator(Y ~ 1)

diagnosis <-
  redesign(design, N = 2:3) |> diagnose_design(sims = 3)

reshape_diagnosis(diagnosis, select = "Power")
```

was previously dropping the `N` column